### PR TITLE
orahost firewall_service defaults to firewalld on OL/EL 8

### DIFF
--- a/roles/orahost/defaults/main.yml
+++ b/roles/orahost/defaults/main.yml
@@ -136,6 +136,7 @@ grid_users:
 # @var firewall_service: $ "firewalld or iptables"
 firewall_service: "{% if ansible_distribution_major_version | int == 6 -%}iptables\
                    {%- elif ansible_distribution_major_version | int == 7 -%}firewalld\
+                   {%- elif ansible_distribution_major_version | int == 8 -%}firewalld\
                    {%- else %}0{% endif %}"
 
 # @var sudoers_template:description: >


### PR DESCRIPTION
When using the orahost role on OL Linux 8, the the firewall_service variable is not populated with firewalld causing the disable_firewall taks to fail (do nothing)